### PR TITLE
Bump firebase peer dependency version to <9

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "react": ">=15 <17",
-    "firebase": ">=6.3.4 <8"
+    "firebase": ">=6.3.4 <9"
   },
   "dependencies": {
     "firebaseui": "^4.7.1"


### PR DESCRIPTION
@gvillenave I wanted to use your version-bumped branch for a side project until the Firebase repo accepts your PR. I forked it to include in my project and noticed that the peer dependency wasn't updated. Not sure what protocol is to update a repo that has an open PR to the true base repo. Very tiny change but figured I could start here since I already did the minimal amount of work 🤷‍♂️ .